### PR TITLE
Prevents check reporting visible incorrectly

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,11 +61,13 @@ module.exports = React.createClass({
     var rect = el.measure((ox, oy, width, height, pageX, pageY) => {
       this.setState({
         rectTop: pageY,
-        rectBottom: pageY + height
+        rectBottom: pageY + height,
+        rectWidth: pageX + width,
       })
     });
     var isVisible = (
-      this.state.rectBottom != 0 && this.state.rectTop >= 0 && this.state.rectBottom <= window.height
+      this.state.rectBottom != 0 && this.state.rectTop >= 0 && this.state.rectBottom <= window.height &&
+      this.state.rectWidth > 0 && this.state.rectWidth <= window.width
     );
 
     // notify the parent when the value changes

--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = React.createClass({
       })
     });
     var isVisible = (
-      this.state.rectTop >= 0 && this.state.rectBottom <= window.height
+      this.state.rectBottom != 0 && this.state.rectTop >= 0 && this.state.rectBottom <= window.height
     );
 
     // notify the parent when the value changes


### PR DESCRIPTION
On initial render, components are reporting that they are visible due to them being sized at 0 height.