### PR TITLE
hooks refactor

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,8 +55,8 @@ exports.InViewPort = class extends Component {
     const window = Dimensions.get('window')
     const isVisible =
       this.state.rectBottom != 0 &&
-      this.state.rectTop >= 0 &&
-      this.state.rectBottom <= window.height &&
+      this.state.rectBottom >= 0 &&
+      this.state.rectTop <= window.height &&
       this.state.rectWidth > 0 &&
       this.state.rectWidth <= window.width
     if (this.lastValue !== isVisible) {


### PR DESCRIPTION
React lifecycle methods like `componentWillMount` or `componentWillReceiveProps` are deprecated -- this PR eliminates the need for them. 